### PR TITLE
Correctly handle an array of middleware

### DIFF
--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -69,7 +69,7 @@ var PromiseRouter = function (path) {
         var original = '__' + method;
         me[original] = me[method];
         me[method] = function () {
-            var args = _.map(arguments, function (arg, idx) {
+            var args = _.flattenDeep(arguments).map(function (arg, idx) {
                 if (idx === 0 && 'string' === typeof arg || arg instanceof RegExp) {
                     return arg;
                 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "bluebird": "^2.3.0",
-    "lodash": "^2.4.1",
+    "lodash": "^3.3.1",
     "methods": "^1.0.0"
   },
   "peerDependencies": {

--- a/test/express-promise-router.test.js
+++ b/test/express-promise-router.test.js
@@ -202,6 +202,22 @@ describe('express-promise-router', function () {
         }).nodeify(done);
     });
 
+    it('should correctly call an array of handlers', function (done) {
+        var fn1 = sinon.spy(function () {
+            assert(fn2.notCalled);
+            return Promise.resolve('next');
+        });
+        var fn2 = sinon.spy(function (req, res) {
+            res.send();
+        });
+
+        router.get('/foo', [[fn1], [fn2]]);
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).nodeify(done);
+    });
+
     it('should call next("route") if a returned promise is resolved with "route"', function (done) {
         var fn1 = function () {
             return Promise.resolve('route');


### PR DESCRIPTION
The default express router allows you to pass in an array of handlers.

This PR updates `express-promise-router` to correctly handle an array of middleware.