### PR TITLE
Adds support for the new Router().route('/foo') pattern

### DIFF
--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -56,13 +56,11 @@ var wrapHandler = function (handler) {
     };
 };
 
-var wrapMethods = function (instanceToWrap)
+var wrapMethods = function (instanceToWrap, isRoute)
 {
-    var methods = require('methods').concat([
-        'use',
-        'all',
-        'param'
-    ]);
+    var toConcat = isRoute ? ['all'] : ['use','all','param'];
+    
+    var methods = require('methods').concat();
 
     _.each(methods, function (method) {
         var original = '__' + method;
@@ -89,8 +87,8 @@ var PromiseRouter = function (path)
     me.__route = me.route;
     me.route = function(path)
     {
-        return wrapMethods(me.__route(path));
-    };
+        return wrapMethods(me.__route(path), true);
+    }
 
     return me;
 };

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -56,9 +56,8 @@ var wrapHandler = function (handler) {
     };
 };
 
-var PromiseRouter = function (path) {
-    var me = new Router(path);
-
+var wrapMethods = function (instanceToWrap)
+{
     var methods = require('methods').concat([
         'use',
         'all',
@@ -67,18 +66,31 @@ var PromiseRouter = function (path) {
 
     _.each(methods, function (method) {
         var original = '__' + method;
-        me[original] = me[method];
-        me[method] = function () {
+        instanceToWrap[original] = instanceToWrap[method];
+        instanceToWrap[method] = function () {
             var args = _.flattenDeep(arguments).map(function (arg, idx) {
-                if (idx === 0 && 'string' === typeof arg || arg instanceof RegExp) {
+                if (idx === 0 && ('string' === typeof arg || arg instanceof RegExp)) {
                     return arg;
                 }
                 return wrapHandler(arg);
             });
 
-            return me[original].apply(this, args);
+            return instanceToWrap[original].apply(this, args);
         };
     });
+
+    return instanceToWrap;
+};
+
+var PromiseRouter = function (path)
+{
+    var me = wrapMethods(new Router(path));
+
+    me.__route = me.route;
+    me.route = function(path)
+    {
+        return wrapMethods(me.__route(path));
+    };
 
     return me;
 };

--- a/test/express-promise-router.route.test.js
+++ b/test/express-promise-router.route.test.js
@@ -1,0 +1,351 @@
+'use strict';
+
+var assert = require('chai').assert;
+var Promise = require('bluebird');
+var sinon = require('sinon');
+var express = require('express');
+var request = Promise.promisify(require('request'));
+
+var delay = function (method, payload) {
+    setTimeout(function () {
+        method(payload);
+    }, 10);
+};
+
+var PromiseRouter = require('../lib/express-promise-router.js');
+
+describe('new Router().route(...)', function () {
+    var app;
+    var serverListening;
+    var server;
+    var router;
+
+    var GET = function (route) {
+        return request('http://localhost:12345' + route).spread(function (res) {
+            // Express sends 500 errors for uncaught exceptions (like failed assertions)
+            // Make sure to still fail the test if an assertion in middleware failed.
+            assert.equal(res.statusCode, 200);
+            return res;
+        });
+    };
+
+    var bootstrap = function (router) {
+        app = express();
+        app.use('/', router);
+
+        if (serverListening) { throw 'already bootstrapped'; }
+
+        serverListening = new Promise(function (resolve, reject) {
+            server = app.listen(12345, function (err) {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+
+        return serverListening;
+    };
+
+    beforeEach(function () {
+        router = new PromiseRouter();
+    });
+
+    afterEach(function (done) {
+        if (serverListening)
+        {
+            serverListening.then(function () {
+                server.close();
+                app = undefined;
+                server = undefined;
+                serverListening = undefined;
+            }).then(done, done);
+        } else {
+            done();
+        }
+    });
+
+    it('should call next with an error when a returned promise is rejected', function (done) {
+        var callback = sinon.spy();
+
+        router.route('/foo')
+        .get(function () {
+            return new Promise(function (resolve, reject) {
+                delay(reject, 'some error');
+            });
+        });
+        router.use(function (err, req, res, next) {
+            assert.equal('some error', err);
+            callback();
+            res.send();
+        });
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).then(function () {
+            assert(callback.calledOnce);
+        }).nodeify(done);
+    });
+
+    it('should call next without an error when a returned promise is resolved with "next"', function (done) {
+        var errorCallback = sinon.spy();
+        var nextCallback = sinon.spy();
+
+        router.route('/foo')
+        .get(function () {
+            return new Promise(function (resolve) {
+                delay(resolve, 'next');
+            });
+        })
+        .all(function (req, res) {
+            nextCallback();
+            res.send();
+        });
+        router.use(function (err, req, res, next) {
+            errorCallback();
+            next();
+        });
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).then(function () {
+            assert(errorCallback.notCalled);
+            assert(nextCallback.calledOnce);
+        }).nodeify(done);
+    });
+
+    it('should not call next when a returned promise is resolved with anything other than "route" or "next"', function (done) {
+        var callback = sinon.spy();
+
+        router.route('/foo')
+        .get(function (req, res) {
+            return new Promise(function (resolve) {
+                res.send();
+                delay(resolve, 'something');
+            });
+        });
+        router.route('/bar')
+        .get(function (req, res) {
+            return new Promise(function (resolve) {
+                res.send();
+                delay(resolve, {});
+            });
+        });
+        router.use(function (req, res) {
+            callback();
+            res.send(500);
+        });
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).then(function () {
+            assert(callback.notCalled);
+            return GET('/bar');
+        }).then(function () {
+            assert(callback.notCalled);
+        }).nodeify(done);
+    });
+
+    it('should move to the next middleware when next is called without an error', function (done) {
+        var callback = sinon.spy();
+
+        router.route('/foo')
+        .get(function (req, res, next) {
+            next();
+        })
+        .all(function (req, res, next) {
+            callback();
+            res.send();
+        });
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).then(function () {
+            assert(callback.calledOnce);
+        }).nodeify(done);
+    });
+
+    it('should move to the next error handler when next is called with an error', function (done) {
+        var callback = sinon.spy();
+        var errorCallback = sinon.spy();
+
+        router.route('/foo')
+        .get(function (req, res, next) {
+            next('an error');
+        })
+        .all(function (req, res, next) {
+            callback();
+            next();
+        });
+        router.use(function (err, req, res, next) {
+            assert.equal('an error', err);
+            errorCallback();
+            res.send();
+        });
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).then(function () {
+            assert(errorCallback.calledOnce);
+            assert(callback.notCalled);
+        }).nodeify(done);
+    });
+
+    it('should call chained handlers in the correct order', function (done) {
+        var fn1 = sinon.spy(function () {
+            assert(fn2.notCalled);
+            return Promise.resolve('next');
+        });
+        var fn2 = sinon.spy(function (req, res) {
+            res.send();
+        });
+
+        router.route('/foo').get(fn1, fn2);
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).nodeify(done);
+    });
+
+    it('should correctly call an array of handlers', function (done) {
+        var fn1 = sinon.spy(function () {
+            assert(fn2.notCalled);
+            return Promise.resolve('next');
+        });
+        var fn2 = sinon.spy(function (req, res) {
+            res.send();
+        });
+
+        router.route('/foo').get([[fn1], [fn2]]);
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).nodeify(done);
+    });
+
+    it('should call next("route") if a returned promise is resolved with "route"', function (done) {
+        var fn1 = function () {
+            return Promise.resolve('route');
+        };
+        var fn2 = function () {
+            assert.fail();
+        };
+
+        router.route('/foo')
+        .get(fn1, fn2);
+        
+        router.route('/foo')
+        .get(function (req, res) {
+            res.send();
+        });
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).nodeify(done);
+    });
+
+
+    it('should bind to RegExp routes', function (done) {
+        var fn1 = function (req, res) {
+            res.send();
+        };
+
+        router.route(/^\/foo/)
+        .get(fn1);
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).nodeify(done);
+    });
+
+    it('multiple calls to handlers that have used "next" should not interfere with each other', function (done) {
+        var fn = sinon.spy(function (req, res, next) {
+            if (fn.calledOnce) {
+                next('error');
+            } else {
+                setTimeout(function () {
+                    res.status(200).send('ok');
+                }, 15);
+            }
+        });
+        var errHandler = function (err, req, res, next) {
+            if (err === 'error') {
+                res.send('fail');
+            } else {
+                next(err);
+            }
+        };
+
+        router.route('/foo').get(fn, errHandler);
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).then(function (res) {
+            assert.equal(res.body, 'fail');
+            return GET('/foo');
+        }).then(function (res) {
+            assert.equal(res.body, 'ok');
+        }).nodeify(done);
+    });
+
+    it('calls next if next is called even if the handler returns a promise', function (done) {
+        var fn = function (req, res, next) {
+            next();
+            return new Promise(function (resolve, reject) {
+            });
+        };
+        var fn2 = function (req, res) {
+            res.send('ok');
+        };
+        var errHandler = function (err, req, res, next) {
+            res.send('error');
+        };
+
+        router.route('/foo').get(fn, fn2, errHandler);
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).then(function (res) {
+            assert.equal(res.body, 'ok');
+        }).nodeify(done);
+    });
+
+    it('calls next with an error if the returned promise is rejected with no reason', function (done) {
+        var fn = function () {
+            return new Promise(function (resolve, reject) {
+                delay(reject, null);
+            });
+        };
+        var errHandler = function (err, req, res, next) {
+            res.send('error');
+        };
+
+        router.route('/foo').get(fn, errHandler);
+
+        bootstrap(router).then(function () {
+            return GET('/foo');
+        }).then(function (res) {
+            assert.equal(res.body, 'error');
+        }).nodeify(done);
+    });
+
+    it('should handle resolved promises returned in req.param() calls', function (done) {
+        router.param('id', function () {
+            return new Promise(function (resolve) {
+                delay(resolve, 'next');
+            });
+        });
+        router.route('/foo/:id')
+        .all(function (req, res) {
+            res.send('done');
+        });
+
+        bootstrap(router).then(function () {
+            return GET('/foo/1');
+        }).then(function (res) {
+            assert.equal(res.body, 'done');
+        }).nodeify(done);
+    });
+
+});


### PR DESCRIPTION
As requested by #18 this PR adds support for the missing error handling while using the `new Router().route("/foo")` pattern.

I made changes so promise rejections get handled as they normally would when using something like:
`new Router().get("/foo", function that returns rejected promise)`
So now one can use:
`new Router().route("/foo").get(function that returns rejected promise)`
and get the same expected results.

I also added specific tests (I just copied your other test file and made changes to use this pattern). Sorry for not trying too much regarding the tests, I just made sure they work as expected.

Let me know if anything else needs changed.