### PR TITLE
Fix two issues and add better error reporting

### DIFF
--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -8,6 +8,11 @@ var isPromise = function (obj) {
 };
 
 var wrapHandler = function (handler) {
+    if (typeof handler !== 'function') {
+        var type = Object.prototype.toString.call(handler);
+        var msg = 'Expected a callback function but got a ' + type;
+        throw new Error(msg);
+    }
 
     var handleReturn = function (args) {
         var wrappedNext;

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -24,6 +24,11 @@ var wrapHandler = function (handler) {
         var promises = [nextPromise];
 
         var next = args.slice(-1)[0];
+
+        if ('string' === typeof next) {
+            next = args.slice(-2)[0];
+        }
+
         var ret = handler.apply(null, args);
 
         if (isPromise(ret)) {

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -8,7 +8,7 @@ var isPromise = function (obj) {
 };
 
 var wrapHandler = function (handler) {
-    if (typeof handler !== 'function') {
+    if ('function' !== typeof handler) {
         var type = Object.prototype.toString.call(handler);
         var msg = 'Expected a callback function but got a ' + type;
         throw new Error(msg);
@@ -76,12 +76,28 @@ var wrapMethods = function (instanceToWrap, isRoute)
         var original = '__' + method;
         instanceToWrap[original] = instanceToWrap[method];
         instanceToWrap[method] = function () {
-            var args = _.flattenDeep(arguments).map(function (arg, idx) {
-                if (idx === 0 && ('string' === typeof arg || arg instanceof RegExp)) {
-                    return arg;
-                }
+            // Manipulating arguments directly is discouraged
+            var args = new Array(arguments.length); 
+            for(var i = 0; i < arguments.length; ++i) {
+                args[i] = arguments[i];
+            }
+
+            // Grab the first parameter out in case it's a route or array of routes.
+            var first = null;
+            if ('string' === typeof args[0] || args[0] instanceof RegExp ||
+                    (Array.isArray(args[0]) && 'string' === typeof args[0][0] || args[0][0] instanceof RegExp)) {
+                first = args[0];
+                args = args.slice(1);
+            }
+
+            args = _.flattenDeep(args).map(function (arg) {
                 return wrapHandler(arg);
             });
+
+            // If we have a route path or something, push it in front
+            if (first) {
+                args.unshift(first);
+            }
 
             return instanceToWrap[original].apply(this, args);
         };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "chai": "^1.9.1",
     "express": "4.x",
     "grunt": "^0.4.4",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "~0.7.0",
     "grunt-mocha-test": "^0.10.2",
     "jshint-stylish": "~0.1.3",

--- a/test/express-promise-router.test.js
+++ b/test/express-promise-router.test.js
@@ -337,4 +337,31 @@ describe('express-promise-router', function () {
         }).nodeify(done);
     });
 
+    it('should call next with unresolved promises returned in req.param() calls', function (done) {
+        var assertOutput = 'error in param';
+
+        router.param('id', function (req, res, next, id) {
+            return new Promise(function (resolve, reject) {
+                delay(reject, assertOutput);
+            });
+        });
+
+        var fn = function(req, res) {
+            res.send('done');
+        };
+
+        var errHandler = function (err, req, res, next) {
+            res.send(err);
+        };
+
+        router.use('/foo/:id', fn);
+
+        router.use(errHandler);
+
+        bootstrap(router).then(function () {
+            return GET('/foo/1');
+        }).then(function (res) {
+            assert.equal(res.body, assertOutput);
+        }).nodeify(done);
+    });
 });

--- a/test/express-promise-router.test.js
+++ b/test/express-promise-router.test.js
@@ -364,4 +364,10 @@ describe('express-promise-router', function () {
             assert.equal(res.body, assertOutput);
         }).nodeify(done);
     });
+
+    it('should throw sensible errors when handler is not a function', function () {
+        assert.throws(function () {
+            router.use('/foo/:id', null);
+        }, /callback/);
+    });
 });

--- a/test/express-promise-router.test.js
+++ b/test/express-promise-router.test.js
@@ -365,6 +365,22 @@ describe('express-promise-router', function () {
         }).nodeify(done);
     });
 
+    it('support array in routes values', function (done) {
+        router.use(['/', '/foo/:bar'], function(req, res) {
+            res.send('done');
+        });
+
+        bootstrap(router).then(function () {
+            return GET('/');
+        }).then(function (res) {
+            assert.equal(res.body, 'done');
+
+            return GET('/foo/1');
+        }).then(function (res) {
+            assert.equal(res.body, 'done');
+        }).nodeify(done);
+    });
+
     it('should throw sensible errors when handler is not a function', function () {
         assert.throws(function () {
             router.use('/foo/:id', null);


### PR DESCRIPTION
* Fix `router.param` support
* Add array of route support
* Generate better error if handler is not a function
* Made some optimization

Optimised instanceToWrap[method] so it should now be V8 optimized.