### PR TITLE
Replace `isPromise` with `is-promise`

### DIFF
--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -4,7 +4,7 @@ var _ = require('lodash');
 
 var isPromise = function (obj) {
     // Just verify that this is a 'thennable' object
-    return obj && 'object' === typeof(obj) && obj.then !== undefined;
+    return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
 };
 
 var wrapHandler = function (handler) {

--- a/lib/express-promise-router.js
+++ b/lib/express-promise-router.js
@@ -1,11 +1,7 @@
 var Router = require('express').Router;
 var Promise = require('bluebird');
 var _ = require('lodash');
-
-var isPromise = function (obj) {
-    // Just verify that this is a 'thennable' object
-    return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
-};
+var isPromise = require('is-promise');
 
 var wrapHandler = function (handler) {
     if ('function' !== typeof handler) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "bluebird": "^3.4.1",
+    "is-promise": "^2.1.0",
     "lodash": "^4.13.1",
     "methods": "^1.0.0"
   },


### PR DESCRIPTION
I'd recommend to externalize the implementation of `isPromise` to match a more standard one.
This has brings a slight change in semantics with it:

```js
// old
return obj && 'object' === typeof(obj) && obj.then !== undefined;

// is-promise
return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
```

The old implementation would, for example accept this as a promise:

```js
// example from is-promise
isPromise({then: true}) //=>false
```

Even if this changes semantics, i'd still consider it a fix.

Let me know what you think about it ☺️ 